### PR TITLE
Fix issues when the summary is too long and no spaces

### DIFF
--- a/src/AgileStoryPrint/JiraBundle/Resources/views/StoryCard/card.html.twig
+++ b/src/AgileStoryPrint/JiraBundle/Resources/views/StoryCard/card.html.twig
@@ -116,6 +116,14 @@
         .version {
             width: 158mm;
         }
+
+        .wrap { 
+           white-space: pre-wrap;      /* CSS3 */   
+           white-space: -moz-pre-wrap; /* Firefox */    
+           white-space: -pre-wrap;     /* Opera <7 */   
+           white-space: -o-pre-wrap;   /* Opera 7 */    
+           word-wrap: break-word;      /* IE */
+        }
     </style>
     </head>
     <body>
@@ -126,7 +134,7 @@
             <div class="value">{{ story.getEffort() }}</div>
         </div>
 
-        <div class="summary">{{ story.getSummary() }}</div>
+        <div class="summary wrap">{{ story.getSummary() }}</div>
 
         <hr />
 


### PR DESCRIPTION
Long summaries are now auto-wrapped.

Fix the issue #10